### PR TITLE
More idiomatic rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +200,12 @@ dependencies = [
  "backtrace",
  "version_check",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "futures"
@@ -320,10 +342,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "memchr"
@@ -458,8 +492,10 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "error-chain",
+ "lazy_static",
  "rand",
  "rstest",
+ "tempfile",
  "time",
  "walkdir",
 ]
@@ -509,6 +545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "same-file"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +597,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ clap_complete_nushell = "4.4"
 walkdir = "1"
 time = "0.1"
 error-chain = "0.12"
+lazy_static = "1.4"
+tempfile = "3"
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ clap_complete_nushell = "4.4"
 walkdir = "1"
 time = "0.1"
 error-chain = "0.12"
-lazy_static = "1.4"
-tempfile = "3"
 
 [dev-dependencies]
+lazy_static = "1.4"
 rand = "0.8"
 rstest = "0.18"
+tempfile = "3"
 
 [profile.release]
 opt-level = "s"

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,6 +42,8 @@ pub struct Args {
     pub completions: Option<String>,
 }
 
+// TODO: Replace `force` with a general non-interactive flag
+
 struct IsDefault {
     graveyard: bool,
     decompose: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -66,40 +66,36 @@ impl IsDefault {
     }
 }
 
+#[allow(clippy::nonminimal_bool)]
 pub fn validate_args(cli: &Args) -> Result<(), Error> {
     let defaults = IsDefault::new(cli);
 
     // [completions] can only be used by itself
-    if !defaults.completions {
-        if !(defaults.graveyard
+    if !defaults.completions
+        && !(defaults.graveyard
             && defaults.decompose
             && defaults.force
             && defaults.seance
             && defaults.unbury
             && defaults.inspect)
-        {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "--completions can only be used by itself",
-            ));
-        }
+    {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "--completions can only be used by itself",
+        ));
     }
     // Furthermore, [force] and [decompose] only work with eachother
-    if !defaults.force {
-        if !(defaults.seance && defaults.unbury && defaults.inspect) {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "-f,--force can only be used with -d,--decompose and --graveyard",
-            ));
-        }
+    if !defaults.force && !(defaults.seance && defaults.unbury && defaults.inspect) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "-f,--force can only be used with -d,--decompose and --graveyard",
+        ));
     }
-    if !defaults.decompose {
-        if !(defaults.seance && defaults.unbury && defaults.inspect) {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "-d,--decompose can only be used with -f,--force and --graveyard",
-            ));
-        }
+    if !defaults.decompose && !(defaults.seance && defaults.unbury && defaults.inspect) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "-d,--decompose can only be used with -f,--force and --graveyard",
+        ));
     }
 
     Ok(())

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,10 +16,6 @@ pub struct Args {
     #[arg(short, long)]
     pub decompose: bool,
 
-    /// Deletes the graveyard without confirmation
-    #[arg(short, long)]
-    pub force: bool,
-
     /// Prints files that were deleted
     /// in the current working directory
     #[arg(short, long)]
@@ -42,12 +38,9 @@ pub struct Args {
     pub completions: Option<String>,
 }
 
-// TODO: Replace `force` with a general non-interactive flag
-
 struct IsDefault {
     graveyard: bool,
     decompose: bool,
-    force: bool,
     seance: bool,
     unbury: bool,
     inspect: bool,
@@ -60,7 +53,6 @@ impl IsDefault {
         IsDefault {
             graveyard: cli.graveyard == defaults.graveyard,
             decompose: cli.decompose == defaults.decompose,
-            force: cli.force == defaults.force,
             seance: cli.seance == defaults.seance,
             unbury: cli.unbury == defaults.unbury,
             inspect: cli.inspect == defaults.inspect,
@@ -77,7 +69,6 @@ pub fn validate_args(cli: &Args) -> Result<(), Error> {
     if !defaults.completions
         && !(defaults.graveyard
             && defaults.decompose
-            && defaults.force
             && defaults.seance
             && defaults.unbury
             && defaults.inspect)
@@ -87,17 +78,10 @@ pub fn validate_args(cli: &Args) -> Result<(), Error> {
             "--completions can only be used by itself",
         ));
     }
-    // Furthermore, [force] and [decompose] only work with eachother
-    if !defaults.force && !(defaults.seance && defaults.unbury && defaults.inspect) {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            "-f,--force can only be used with -d,--decompose and --graveyard",
-        ));
-    }
     if !defaults.decompose && !(defaults.seance && defaults.unbury && defaults.inspect) {
         return Err(Error::new(
             ErrorKind::InvalidInput,
-            "-d,--decompose can only be used with -f,--force and --graveyard",
+            "-d,--decompose can only be used with --graveyard",
         ));
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,7 +16,7 @@ pub struct Args {
     #[arg(short, long)]
     pub decompose: bool,
 
-    /// Deletes without confirmation
+    /// Deletes the graveyard without confirmation
     #[arg(short, long)]
     pub force: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// File or directory to remove
@@ -53,17 +53,18 @@ struct IsDefault {
     inspect: bool,
     completions: bool,
 }
-// Make this with ::new instead the proper RustLang way:
+
 impl IsDefault {
     fn new(cli: &Args) -> IsDefault {
+        let defaults = Args::default();
         IsDefault {
-            graveyard: cli.graveyard.is_none(),
-            decompose: !cli.decompose,
-            force: !cli.force,
-            seance: !cli.seance,
-            unbury: cli.unbury.is_none(),
-            inspect: !cli.inspect,
-            completions: cli.completions.is_none(),
+            graveyard: cli.graveyard == defaults.graveyard,
+            decompose: cli.decompose == defaults.decompose,
+            force: cli.force == defaults.force,
+            seance: cli.seance == defaults.seance,
+            unbury: cli.unbury == defaults.unbury,
+            inspect: cli.inspect == defaults.inspect,
+            completions: cli.completions == defaults.completions,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub struct RecordItem<'a> {
 
 pub fn run<M>(cli: args::Args, mode: M) -> Result<(), Error>
 where
-    M: util::ValueSource,
+    M: util::TestingMode,
 {
     args::validate_args(&cli)?;
     // This selects the location of deleted
@@ -222,7 +222,7 @@ where
 
 fn do_inspection<M>(target: PathBuf, source: &PathBuf, metadata: Metadata, mode: &M) -> bool
 where
-    M: util::ValueSource,
+    M: util::TestingMode,
 {
     if metadata.is_dir() {
         // Get the size of the directory and all its contents
@@ -299,7 +299,7 @@ where
 
 pub fn bury<S: AsRef<Path>, D: AsRef<Path>, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
 where
-    M: util::ValueSource,
+    M: util::TestingMode,
 {
     let (source, dest) = (source.as_ref(), dest.as_ref());
     // Try a simple rename, which will only work within the same mount point.
@@ -388,7 +388,7 @@ where
 
 fn copy_file<S: AsRef<Path>, D: AsRef<Path>, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
 where
-    M: util::ValueSource,
+    M: util::TestingMode,
 {
     let (source, dest) = (source.as_ref(), dest.as_ref());
     let metadata = fs::symlink_metadata(source)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,7 @@ pub fn run(cli: args::Args) -> Result<(), Error> {
     // If the user wishes to restore everything
     if cli.decompose {
         if cli.force || util::prompt_yes("Really unlink the entire graveyard?") {
-            if let Err(e) = fs::remove_dir_all(graveyard) {
-                return Err(Error::new(e.kind(), "Couldn't unlink graveyard"));
-            }
+            fs::remove_dir_all(graveyard)?;
         }
         return Ok(());
     }
@@ -121,14 +119,14 @@ pub fn run(cli: args::Args) -> Result<(), Error> {
         }
 
         // Reopen the record and then delete lines corresponding to exhumed graves
-        if let Err(e) = fs::File::open(record)
+        fs::File::open(record)
             .and_then(|f| delete_lines_from_record(f, record, &graves_to_exhume))
-        {
-            return Err(Error::new(
-                e.kind(),
-                format!("Failed to remove unburied files from record: {}", e),
-            ));
-        }
+            .map_err(|e| {
+                Error::new(
+                    e.kind(),
+                    format!("Failed to remove unburied files from record: {}", e),
+                )
+            })?;
         return Ok(());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub struct RecordItem<'a> {
 }
 
 pub fn run(cli: args::Args) -> Result<(), Error> {
-    args::validate_args(&cli).unwrap();
+    args::validate_args(&cli)?;
     // This selects the location of deleted
     // files based on the following order (from
     // first choice to last):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub fn run(cli: args::Args) -> Result<(), Error> {
     };
 
     if !graveyard.exists() {
-        fs::create_dir(&graveyard)?;
+        fs::create_dir_all(&graveyard)?;
         let metadata = graveyard.metadata()?;
         let mut permissions = metadata.permissions();
         permissions.set_mode(0o700);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use walkdir::WalkDir;
 pub mod args;
 pub mod util;
 
+use args::Args;
+
 const GRAVEYARD: &str = "/tmp/graveyard";
 const RECORD: &str = ".record";
 const LINES_TO_INSPECT: usize = 6;
@@ -21,10 +23,7 @@ pub struct RecordItem<'a> {
     dest: &'a Path,
 }
 
-pub fn run<M>(cli: args::Args, mode: M) -> Result<(), Error>
-where
-    M: util::TestingMode,
-{
+pub fn run<M: util::TestingMode>(cli: Args, mode: M) -> Result<(), Error> {
     args::validate_args(&cli)?;
     // This selects the location of deleted
     // files based on the following order (from
@@ -214,16 +213,18 @@ where
             }
         }
     } else {
-        let _ = args::Args::command().print_help();
+        let _ = Args::command().print_help();
     }
 
     Ok(())
 }
 
-fn do_inspection<M>(target: PathBuf, source: &PathBuf, metadata: Metadata, mode: &M) -> bool
-where
-    M: util::TestingMode,
-{
+fn do_inspection<M: util::TestingMode>(
+    target: PathBuf,
+    source: &PathBuf,
+    metadata: Metadata,
+    mode: &M,
+) -> bool {
     if metadata.is_dir() {
         // Get the size of the directory and all its contents
         println!(
@@ -297,8 +298,10 @@ where
     Ok(())
 }
 
-pub fn bury<S: AsRef<Path>, D: AsRef<Path>, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
+pub fn bury<S, D, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
 where
+    S: AsRef<Path>,
+    D: AsRef<Path>,
     M: util::TestingMode,
 {
     let (source, dest) = (source.as_ref(), dest.as_ref());
@@ -386,8 +389,10 @@ where
     Ok(())
 }
 
-fn copy_file<S: AsRef<Path>, D: AsRef<Path>, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
+fn copy_file<S, D, M>(source: S, dest: D, mode: &M) -> Result<(), Error>
 where
+    S: AsRef<Path>,
+    D: AsRef<Path>,
     M: util::TestingMode,
 {
     let (source, dest) = (source.as_ref(), dest.as_ref());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::{generate, Shell};
 use clap_complete_nushell::Nushell;
-use rip;
+
 use rip::args;
 use std::io::stdout;
 use std::process::ExitCode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::{generate, Shell};
 use clap_complete_nushell::Nushell;
 
-use rip::args;
+use rip::{args, util};
 use std::io::stdout;
 use std::process::ExitCode;
 
@@ -23,7 +23,7 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    if let Err(ref e) = rip::run(cli) {
+    if let Err(ref e) = rip::run(cli, util::ProductionSource) {
         println!("Exception: {}", e);
         return ExitCode::FAILURE;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    if let Err(ref e) = rip::run(cli, util::ProductionSource) {
+    if let Err(ref e) = rip::run(cli, util::ProductionMode) {
         println!("Exception: {}", e);
         return ExitCode::FAILURE;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,14 +54,10 @@ pub fn humanize_bytes(bytes: u64) -> String {
     let pair = values
         .iter()
         .enumerate()
-        .take_while(|x| bytes as usize / (1000 as usize).pow(x.0 as u32) > 10)
+        .take_while(|x| bytes as usize / (1000_usize).pow(x.0 as u32) > 10)
         .last();
     if let Some((i, unit)) = pair {
-        format!(
-            "{} {}",
-            bytes as usize / (1000 as usize).pow(i as u32),
-            unit
-        )
+        format!("{} {}", bytes as usize / (1000_usize).pow(i as u32), unit)
     } else {
         format!("{} {}", bytes, values[0])
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,8 +35,9 @@ impl TestingMode for ProductionMode {
 }
 
 /// Prompt for user input, returning True if the first character is 'y' or 'Y'
-pub fn prompt_yes<T: AsRef<str>, M>(prompt: T, source: &M) -> bool
+pub fn prompt_yes<T, M>(prompt: T, source: &M) -> bool
 where
+    T: AsRef<str>,
     M: TestingMode,
 {
     print!("{} (y/N) ", prompt.as_ref());

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,12 +23,12 @@ pub fn get_user() -> String {
 }
 
 // Allows injection of test-specific behavior
-pub trait ValueSource {
+pub trait TestingMode {
     fn is_test(&self) -> bool;
 }
 
-pub struct ProductionSource;
-impl ValueSource for ProductionSource {
+pub struct ProductionMode;
+impl TestingMode for ProductionMode {
     fn is_test(&self) -> bool {
         false
     }
@@ -37,7 +37,7 @@ impl ValueSource for ProductionSource {
 /// Prompt for user input, returning True if the first character is 'y' or 'Y'
 pub fn prompt_yes<T: AsRef<str>, M>(prompt: T, source: &M) -> bool
 where
-    M: ValueSource,
+    M: TestingMode,
 {
     print!("{} (y/N) ", prompt.as_ref());
     if io::stdout().flush().is_err() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -157,6 +157,7 @@ fn test_env(#[case] env_var: &str) {
     let test_env = TestEnv::new();
     let test_data = TestData::new(&test_env);
     let modified_graveyard = if env_var == "XDG_DATA_HOME" {
+        // XDG version adds a "graveyard" folder
         util::join_absolute(&test_env.graveyard, "graveyard")
     } else {
         test_env.graveyard.clone()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -74,12 +74,12 @@ fn test_bury_unbury(#[case] decompose: bool) {
     });
 
     // Verify that the file no longer exists
-    assert!(!metadata(&datafile_path).is_ok());
+    assert!(metadata(&datafile_path).is_err());
     // Verify that the graveyard exists
     assert!(metadata(&test_env.graveyard).is_ok());
 
     // And is now in the graveyard
-    let grave_datafile_path = util::join_absolute(&test_env.graveyard, &datafile_path_canonical);
+    let grave_datafile_path = util::join_absolute(&test_env.graveyard, datafile_path_canonical);
     // test_env.graveyard.join(&datafile_path);
     assert!(metadata(&grave_datafile_path).is_ok());
     // with the right data
@@ -99,9 +99,9 @@ fn test_bury_unbury(#[case] decompose: bool) {
         });
 
         // Verify that the graveyard is completely deleted
-        assert!(!metadata(&test_env.graveyard).is_ok());
+        assert!(metadata(&test_env.graveyard).is_err());
         // And that the file was not restored
-        assert!(!metadata(&datafile_path).is_ok());
+        assert!(metadata(&datafile_path).is_err());
     } else {
         // Unbury the file using the CLI
         let _ = rip::run(args::Args {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -86,35 +86,24 @@ fn test_bury_unbury(#[case] decompose: bool) {
     let restored_data_from_grave = read_to_string(&grave_datafile_path).unwrap();
     assert_eq!(restored_data_from_grave, data);
 
-    if decompose {
-        let _ = rip::run(args::Args {
-            targets: Vec::new(),
-            graveyard: Some(test_env.graveyard.clone()),
-            decompose: true,
-            force: true,
-            seance: false,
-            unbury: None,
-            inspect: false,
-            completions: None,
-        });
+    let _ = rip::run(args::Args {
+        targets: Vec::new(),
+        graveyard: Some(test_env.graveyard.clone()),
+        decompose,
+        // So we don't get interactions:
+        force: decompose,
+        seance: false,
+        unbury: if decompose { None } else { Some(Vec::new()) },
+        inspect: false,
+        completions: None,
+    });
 
+    if decompose {
         // Verify that the graveyard is completely deleted
         assert!(metadata(&test_env.graveyard).is_err());
         // And that the file was not restored
         assert!(metadata(&datafile_path).is_err());
     } else {
-        // Unbury the file using the CLI
-        let _ = rip::run(args::Args {
-            targets: Vec::new(),
-            graveyard: Some(test_env.graveyard.clone()),
-            decompose: false,
-            force: false,
-            seance: false,
-            unbury: Some(Vec::new()),
-            inspect: false,
-            completions: None,
-        });
-
         // Verify that the file exists in the original location with the correct data
         assert!(metadata(&datafile_path).is_ok());
         let restored_data = read_to_string(&datafile_path).unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,13 +1,14 @@
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 use rstest::rstest;
-use std::env::temp_dir;
+use std::env::{self, temp_dir};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
 
-use rip::{args, util};
+use rip::{self, args, util};
 
+#[derive(Debug)]
 struct TestEnv {
     tmpdir: PathBuf,
     graveyard: PathBuf,
@@ -41,6 +42,7 @@ impl TestEnv {
     }
 }
 
+#[derive(Debug)]
 struct TestData {
     data: String,
     path: PathBuf,
@@ -54,9 +56,6 @@ impl TestData {
             .map(char::from)
             .collect::<String>();
 
-        println!("Graveyard dir: {}", test_env.graveyard.display());
-        println!("Src dir: {}", test_env.src.display());
-
         let path = test_env.src.join("test_file.txt");
         let mut file = File::create(&path).unwrap();
         file.write_all(data.as_bytes()).unwrap();
@@ -65,6 +64,8 @@ impl TestData {
     }
 }
 
+/// Test that a file is buried and unburied correctly
+/// Also checks that the graveyard is deleted when decompose is true
 #[rstest]
 #[case::unbury(false)]
 #[case::decomposition(true)]
@@ -75,11 +76,12 @@ fn test_bury_unbury(#[case] decompose: bool) {
     let expected_graveyard_path =
         util::join_absolute(&test_env.graveyard, test_data.path.canonicalize().unwrap());
 
-    let _ = rip::run(args::Args {
+    rip::run(args::Args {
         targets: [test_data.path.clone()].to_vec(),
         graveyard: Some(test_env.graveyard.clone()),
         ..args::Args::default()
-    });
+    })
+    .unwrap();
 
     // Verify that the file no longer exists
     assert!(!test_data.path.exists());
@@ -92,13 +94,14 @@ fn test_bury_unbury(#[case] decompose: bool) {
     let restored_data_from_grave = fs::read_to_string(&expected_graveyard_path).unwrap();
     assert_eq!(restored_data_from_grave, test_data.data);
 
-    let _ = rip::run(args::Args {
+    rip::run(args::Args {
         graveyard: Some(test_env.graveyard.clone()),
         decompose,
         force: decompose,
         unbury: if decompose { None } else { Some(Vec::new()) },
         ..args::Args::default()
-    });
+    })
+    .unwrap();
 
     if decompose {
         // Verify that the graveyard is completely deleted
@@ -111,6 +114,68 @@ fn test_bury_unbury(#[case] decompose: bool) {
         let restored_data = fs::read_to_string(&test_data.path).unwrap();
         assert_eq!(restored_data, test_data.data);
     }
+
+    test_env.teardown();
+}
+
+const ENV_VARS: [&str; 2] = ["GRAVEYARD", "XDG_DATA_HOME"];
+
+// Delete env vars and return them
+// so we can restore them later
+fn cache_and_remove_env_vars() -> [Option<String>; 2] {
+    // This should be the same size as ENV_VARS
+    ENV_VARS.map(|key| {
+        // Check if env var exists
+        let value = env::var(key).ok();
+        env::remove_var(key);
+        value
+    })
+}
+
+/// Test that we can set the graveyard from different env variables
+#[rstest]
+#[case::env_graveyard("GRAVEYARD")]
+#[case::env_xdg_data_home("XDG_DATA_HOME")]
+fn test_graveyard_env(#[case] env_var: &str) {
+    let default_env_vars = cache_and_remove_env_vars();
+    let test_env = TestEnv::new();
+    let test_data = TestData::new(&test_env);
+    let modified_graveyard = if env_var == "XDG_DATA_HOME" {
+        util::join_absolute(&test_env.graveyard, "graveyard")
+    } else {
+        test_env.graveyard.clone()
+    };
+    let expected_graveyard_path =
+        util::join_absolute(modified_graveyard, test_data.path.canonicalize().unwrap());
+
+    println!("Graveyard dir: {}", expected_graveyard_path.display());
+
+    let graveyard = test_env.graveyard.clone();
+    env::set_var(env_var, graveyard);
+
+    rip::run(args::Args {
+        targets: [test_data.path.clone()].to_vec(),
+        // We don't set the graveyard here!
+        ..args::Args::default()
+    })
+    .unwrap();
+
+    assert!(!test_data.path.exists());
+    assert!(test_env.graveyard.exists());
+
+    let restored_data = fs::read_to_string(expected_graveyard_path).unwrap();
+    assert_eq!(restored_data, test_data.data);
+
+    // Iterate over the default env vars and restore them
+    ENV_VARS
+        .iter()
+        .zip(default_env_vars.iter())
+        .for_each(|(key, value)| {
+            env::remove_var(key);
+            if let Some(value) = value {
+                env::set_var(key, value);
+            }
+        });
 
     test_env.teardown();
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19,8 +19,8 @@ fn aquire_lock() -> MutexGuard<'static, ()> {
     GLOBAL_LOCK.lock().unwrap()
 }
 
-struct TestSource;
-impl util::ValueSource for TestSource {
+struct TestMode;
+impl util::TestingMode for TestMode {
     fn is_test(&self) -> bool {
         true
     }
@@ -95,7 +95,7 @@ fn test_bury_unbury(#[case] decompose: bool, #[case] inspect: bool) {
             inspect,
             ..args::Args::default()
         },
-        TestSource,
+        TestMode,
     )
     .unwrap();
 
@@ -117,7 +117,7 @@ fn test_bury_unbury(#[case] decompose: bool, #[case] inspect: bool) {
             unbury: if decompose { None } else { Some(Vec::new()) },
             ..args::Args::default()
         },
-        TestSource,
+        TestMode,
     )
     .unwrap();
 
@@ -189,7 +189,7 @@ fn test_env(#[case] env_var: &str) {
             // We don't set the graveyard here!
             ..args::Args::default()
         },
-        TestSource,
+        TestMode,
     )
     .unwrap();
 
@@ -219,7 +219,7 @@ fn test_duplicate_file() {
             graveyard: Some(test_env.graveyard.clone()),
             ..args::Args::default()
         },
-        TestSource,
+        TestMode,
     )
     .unwrap();
 
@@ -241,7 +241,7 @@ fn test_duplicate_file() {
             graveyard: Some(test_env.graveyard.clone()),
             ..args::Args::default()
         },
-        TestSource,
+        TestMode,
     )
     .unwrap();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-use rip::{self, args, util};
+use rip::Args;
+use rip::{self, util};
 use rstest::rstest;
 use std::env;
 use std::fs::{self, File};
@@ -89,11 +90,11 @@ fn test_bury_unbury(#[case] decompose: bool, #[case] inspect: bool) {
         util::join_absolute(&test_env.graveyard, test_data.path.canonicalize().unwrap());
 
     rip::run(
-        args::Args {
+        Args {
             targets: [test_data.path.clone()].to_vec(),
             graveyard: Some(test_env.graveyard.clone()),
             inspect,
-            ..args::Args::default()
+            ..Args::default()
         },
         TestMode,
     )
@@ -111,11 +112,11 @@ fn test_bury_unbury(#[case] decompose: bool, #[case] inspect: bool) {
     assert_eq!(restored_data_from_grave, test_data.data);
 
     rip::run(
-        args::Args {
+        Args {
             graveyard: Some(test_env.graveyard.clone()),
             decompose,
             unbury: if decompose { None } else { Some(Vec::new()) },
-            ..args::Args::default()
+            ..Args::default()
         },
         TestMode,
     )
@@ -184,10 +185,10 @@ fn test_env(#[case] env_var: &str) {
     env::set_var(env_var, graveyard);
 
     rip::run(
-        args::Args {
+        Args {
             targets: [test_data.path.clone()].to_vec(),
             // We don't set the graveyard here!
-            ..args::Args::default()
+            ..Args::default()
         },
         TestMode,
     )
@@ -214,10 +215,10 @@ fn test_duplicate_file() {
         util::join_absolute(&test_env.graveyard, test_data1.path.canonicalize().unwrap());
 
     rip::run(
-        args::Args {
+        Args {
             targets: [test_data1.path.clone()].to_vec(),
             graveyard: Some(test_env.graveyard.clone()),
-            ..args::Args::default()
+            ..Args::default()
         },
         TestMode,
     )
@@ -236,10 +237,10 @@ fn test_duplicate_file() {
     );
 
     rip::run(
-        args::Args {
+        Args {
             targets: [test_data2.path.clone()].to_vec(),
             graveyard: Some(test_env.graveyard.clone()),
-            ..args::Args::default()
+            ..Args::default()
         },
         TestMode,
     )

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -132,6 +132,19 @@ fn cache_and_remove_env_vars() -> [Option<String>; 2] {
     })
 }
 
+fn restore_env_vars(default_env_vars: [Option<String>; 2]) {
+    // Iterate over the default env vars and restore them
+    ENV_VARS
+        .iter()
+        .zip(default_env_vars.iter())
+        .for_each(|(key, value)| {
+            env::remove_var(key);
+            if let Some(value) = value {
+                env::set_var(key, value);
+            }
+        });
+}
+
 /// Test that we can set the graveyard from different env variables
 #[rstest]
 #[case::env_graveyard("GRAVEYARD")]
@@ -166,16 +179,6 @@ fn test_graveyard_env(#[case] env_var: &str) {
     let restored_data = fs::read_to_string(expected_graveyard_path).unwrap();
     assert_eq!(restored_data, test_data.data);
 
-    // Iterate over the default env vars and restore them
-    ENV_VARS
-        .iter()
-        .zip(default_env_vars.iter())
-        .for_each(|(key, value)| {
-            env::remove_var(key);
-            if let Some(value) = value {
-                env::set_var(key, value);
-            }
-        });
-
+    restore_env_vars(default_env_vars);
     test_env.teardown();
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,7 +6,6 @@ use std::fs::{self, metadata, read_to_string, remove_dir_all, File};
 use std::io::Write;
 use std::path::PathBuf;
 
-use rip;
 use rip::{args, util};
 
 struct TestEnv {
@@ -40,11 +39,11 @@ fn teardown_test_env(test_env: TestEnv) {
 }
 
 fn make_test_data() -> String {
-    return rand::thread_rng()
+    rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(100)
         .map(char::from)
-        .collect::<String>();
+        .collect::<String>()
 }
 
 #[rstest]
@@ -61,7 +60,7 @@ fn test_bury_unbury(#[case] decompose: bool) {
     let mut file = File::create(&datafile_path).unwrap();
     let datafile_path_canonical = datafile_path.canonicalize().unwrap();
 
-    file.write(data.as_bytes()).unwrap();
+    file.write_all(data.as_bytes()).unwrap();
 
     let _ = rip::run(args::Args {
         targets: [datafile_path.clone()].to_vec(),


### PR DESCRIPTION
This implements various changes with modern rust code that simplify things, like `?` rather than manually checking the `Err`.

It also:

- Adds several more unit-tests to fill out the code coverage.
- Adds a `TestingMode` trait that can be used to turn on testing-specific branches.
  - Removes the `--force` option which was only necessary for tests.
